### PR TITLE
[FIX] ZeroDivisionError when qty is null

### DIFF
--- a/sale_order_secondary_unit/models/sale_order.py
+++ b/sale_order_secondary_unit/models/sale_order.py
@@ -56,7 +56,7 @@ class SaleOrderLine(models.Model):
     @api.depends("secondary_uom_qty", "product_uom_qty", "price_unit")
     def _compute_secondary_uom_unit_price(self):
         for line in self:
-            if line.secondary_uom_id:
+            if line.secondary_uom_id and line.secondary_uom_qty:
                 line.secondary_uom_unit_price = (
                     line.price_subtotal / line.secondary_uom_qty
                 )


### PR DESCRIPTION
Help you finish OCA PR [#1671](https://github.com/OCA/sale-workflow/pull/1671)

Fixing [that](https://github.com/OCA/sale-workflow/pull/1671#pullrequestreview-725707369)

I needed that for my own 15.0 migration of this module.