### PR TITLE
[FIX] so line qty set to 0 on confirmed so

### DIFF
--- a/sale_global_discount_amount/models/sale.py
+++ b/sale_global_discount_amount/models/sale.py
@@ -40,7 +40,7 @@ class SaleOrder(models.Model):
             else:
                 self.order_line.filtered(lambda x: x.is_discount_line).with_context(
                     discount_lines=True
-                ).write({"product_uom_qty": 0})
+                ).write({"product_uom_qty": 0, "price_unit": 0})
             if self.global_discount_amount != 0.0:
                 self.env["sale.order.line"]._create_discount_lines(order=self)
         return res
@@ -125,6 +125,8 @@ class SaleOrderLine(models.Model):
                     "product_uom_qty": 1,
                 }
             )
+        else:
+            discount_line.product_uom_qty=1
         discount_line.product_id_change()
         price_unit = discount_line._prepare_discount_line_vals(
             amount_untaxed=amount_untaxed,
@@ -136,6 +138,7 @@ class SaleOrderLine(models.Model):
                 "price_unit": -1 * price_unit,
                 "is_discount_line": True,
                 "tax_id": tax_ids,
+
             }
         )
 

--- a/sale_global_discount_amount/tests/test_sale_global_discount_amount.py
+++ b/sale_global_discount_amount/tests/test_sale_global_discount_amount.py
@@ -521,3 +521,20 @@ class TestSaleGlobalDiscountAmount(SavepointCase):
             lambda x: x.tax_ids == self.vat20
         )
         self.assertEqual(discount_line_20.price_unit, -27.78)
+
+    def test_create_updt_qty_to_zero_on_confirmed_so(self):
+        discount_order_lines = self.env["sale.order.line"].search(
+            [
+                ("product_id", "=", self.discount_product.id),
+                ("order_id", "=", self.sale_single_tax.id),
+            ]
+        )
+        self.sale_single_tax.action_confirm()
+        line_1_id = self.sale_single_tax.order_line.filtered(lambda r: not r.discount)[0].id
+        self.assertTrue(self.sale_single_tax.write({"order_line": [(1, line_1_id, {"product_uom_qty": 0})]}))
+        # self.assertEqual(len(discount_order_lines), 1)
+        # self.assertEqual(discount_order_lines[0].is_discount_line, True)
+        # self.assertEqual(discount_order_lines[0].price_unit, -30.00)
+        # self.assertEqual(discount_order_lines[0].product_uom_qty, 1.0)
+        # self.assertEqual(len(discount_order_lines[0].tax_id), 1)
+        # self.assertEqual(discount_order_lines[0].tax_id[0].name, "TEST 10%")


### PR DESCRIPTION
Fix a bug on account_global_discount and sale_global_discount

To reproduce:
confirm an SO with a global discount
modify the qty on std line to 0
a user error msg is raised : You can not remove an order line once the sales order is confirmed.\nYou should rather set the quantity to 0.
this PR depends on an other PR done for the same reason https://github.com/akretion/account-invoicing/pull/12
