### PR TITLE
[ADD] check homogeneous tax include on sales and invoices

### DIFF
--- a/sale_order_pricelist_tax/__manifest__.py
+++ b/sale_order_pricelist_tax/__manifest__.py
@@ -12,6 +12,10 @@
     "data": [
         "views/pricelist_view.xml",
         "views/account_tax_view.xml",
+        "views/sale_order_view.xml",
+        "views/account_move_view.xml",
+        "report/invoice_template.xml",
+        "report/sale_template.xml",
     ],
     "demo": [
         "demo/demo.xml",

--- a/sale_order_pricelist_tax/demo/demo.xml
+++ b/sale_order_pricelist_tax/demo/demo.xml
@@ -100,5 +100,4 @@
         <field name="tax_src_id" ref="account_tax_sale_2" />
         <field name="tax_dest_id" ref="account_tax_sale_inc_papeete_2" />
     </record>
-
 </odoo>

--- a/sale_order_pricelist_tax/i18n/fr.po
+++ b/sale_order_pricelist_tax/i18n/fr.po
@@ -1,0 +1,235 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sale_order_pricelist_tax
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-06-27 14:06+0000\n"
+"PO-Revision-Date: 2022-06-27 16:07+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 3.0.1\n"
+
+#. module: sale_order_pricelist_tax
+#: code:addons/sale_order_pricelist_tax/models/product_pricelist.py:0
+#, python-format
+msgid " (tax include)"
+msgstr " (taxe incluse)"
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model,name:sale_order_pricelist_tax.model_account_move
+msgid "Account Move"
+msgstr ""
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_account_fiscal_position__display_name
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_account_move__display_name
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_account_tax__display_name
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_price_include_tax_mixin__display_name
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_product_pricelist__display_name
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_product_product__display_name
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_sale_order__display_name
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr "Nom affiché"
+
+#. module: sale_order_pricelist_tax
+#: code:addons/sale_order_pricelist_tax/models/account_tax.py:0
+#, python-format
+msgid "Equivalent price exclude tax for '%s' is missing"
+msgstr "Prix équivalent avec taxe exclue pour  '%s' est manquant"
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model.fields.selection,name:sale_order_pricelist_tax.selection__account_move__price_tax_state__exception
+#: model:ir.model.fields.selection,name:sale_order_pricelist_tax.selection__price_include_tax_mixin__price_tax_state__exception
+#: model:ir.model.fields.selection,name:sale_order_pricelist_tax.selection__sale_order__price_tax_state__exception
+msgid "Exception"
+msgstr ""
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model.fields.selection,name:sale_order_pricelist_tax.selection__account_move__price_tax_state__exclude
+#: model:ir.model.fields.selection,name:sale_order_pricelist_tax.selection__price_include_tax_mixin__price_tax_state__exclude
+#: model:ir.model.fields.selection,name:sale_order_pricelist_tax.selection__sale_order__price_tax_state__exclude
+msgid "Exclude"
+msgstr ""
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model,name:sale_order_pricelist_tax.model_account_fiscal_position
+msgid "Fiscal Position"
+msgstr "Position fiscale"
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_account_fiscal_position__id
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_account_move__id
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_account_tax__id
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_price_include_tax_mixin__id
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_product_pricelist__id
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_product_product__id
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_sale_order__id
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model.fields,help:sale_order_pricelist_tax.field_product_pricelist__price_include_taxes
+msgid ""
+"If checked, prices of the list are taken account tax include.\n"
+"We can only update this setting if there is no price item."
+msgstr ""
+"Si activé, les prix de la liste sont considérés comme taxe incluse.\n"
+"Le changement est possible s'il n'y a pas encore de prix renseigné."
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model.fields.selection,name:sale_order_pricelist_tax.selection__account_move__price_tax_state__include
+#: model:ir.model.fields.selection,name:sale_order_pricelist_tax.selection__price_include_tax_mixin__price_tax_state__include
+#: model:ir.model.fields.selection,name:sale_order_pricelist_tax.selection__sale_order__price_tax_state__include
+msgid "Include"
+msgstr ""
+
+#. module: sale_order_pricelist_tax
+#: code:addons/sale_order_pricelist_tax/models/account_move.py:0
+#, python-format
+msgid ""
+"Invoice lines must have the same kind of taxes (price include or exclude)."
+msgstr ""
+"Les lignes de facture doivent avoir le même type de taxe (prix inclus ou "
+"prix exclus)."
+
+#. module: sale_order_pricelist_tax
+#: model_terms:ir.ui.view,arch_db:sale_order_pricelist_tax.account_move_view_form
+msgid ""
+"Invoice lines must have the same type of tax:\n"
+"                     <br/> - Either price include tax\n"
+"                    <br/> - Either price exclude tax"
+msgstr ""
+"Les lignes de facture doivent avoir le même type de taxe:\n"
+"                     <br/> -Soit Prix Inclus\n"
+"                    <br/> - Soit Prix Exclus"
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_account_fiscal_position____last_update
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_account_move____last_update
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_account_tax____last_update
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_price_include_tax_mixin____last_update
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_product_pricelist____last_update
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_product_product____last_update
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_sale_order____last_update
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_sale_order_line____last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: sale_order_pricelist_tax
+#: code:addons/sale_order_pricelist_tax/models/product_pricelist.py:0
+#, python-format
+msgid ""
+"Only price items with 'Based on' field set to 'Public Price' are "
+"supported.\n"
+msgstr ""
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model,name:sale_order_pricelist_tax.model_price_include_tax_mixin
+msgid "Price Include Tax Check Mixin"
+msgstr ""
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_product_pricelist__price_include_taxes
+msgid "Price include taxes"
+msgstr "Prix avec taxes incluses"
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_account_bank_statement_line__price_tax_state
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_account_move__price_tax_state
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_account_payment__price_tax_state
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_price_include_tax_mixin__price_tax_state
+#: model:ir.model.fields,field_description:sale_order_pricelist_tax.field_sale_order__price_tax_state
+msgid "Price tax state"
+msgstr ""
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model,name:sale_order_pricelist_tax.model_product_pricelist
+msgid "Pricelist"
+msgstr "Liste de prix"
+
+#. module: sale_order_pricelist_tax
+#: model:product.pricelist,name:sale_order_pricelist_tax.ht_pricelist
+msgid "Prix HT"
+msgstr ""
+
+#. module: sale_order_pricelist_tax
+#: model:product.pricelist,name:sale_order_pricelist_tax.ttc_pricelist
+msgid "Prix TTC"
+msgstr ""
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model,name:sale_order_pricelist_tax.model_product_product
+msgid "Product"
+msgstr "Article"
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model,name:sale_order_pricelist_tax.model_sale_order
+msgid "Sale Order"
+msgstr ""
+
+#. module: sale_order_pricelist_tax
+#: code:addons/sale_order_pricelist_tax/models/sale_order.py:0
+#, python-format
+msgid ""
+"Sale Order lines must have the same kind of taxes (price include or "
+"exclude)."
+msgstr ""
+"Les lignes de commande doivent avoir le même type de taxe (prix inclus ou "
+"prix exclus)."
+
+#. module: sale_order_pricelist_tax
+#: model_terms:ir.ui.view,arch_db:sale_order_pricelist_tax.view_order_form
+msgid ""
+"Sale Order lines must have the same type of tax:\n"
+"                     <br/> - Either price include tax\n"
+"                    <br/> - Either price exclude tax"
+msgstr ""
+"Les lignes de commande doivent avoir le même type de taxe:\n"
+"                     <br/> -Soit Prix Inclus\n"
+"                    <br/> - Soit Prix Exclus"
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model,name:sale_order_pricelist_tax.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Ligne de bons de commande"
+
+#. module: sale_order_pricelist_tax
+#: model:ir.model,name:sale_order_pricelist_tax.model_account_tax
+msgid "Tax"
+msgstr "Taxe"
+
+#. module: sale_order_pricelist_tax
+#: code:addons/sale_order_pricelist_tax/models/account_tax.py:0
+#, python-format
+msgid "Tax product '%s' is price exclude. You must switch to include ones."
+msgstr ""
+"Le prix du produit '%s' est avec une taxe exclue. Vous devez prendre un "
+"prix en taxe inclue."
+
+#. module: sale_order_pricelist_tax
+#: code:addons/sale_order_pricelist_tax/models/sale_order.py:0
+#, python-format
+msgid "Tax with include price with pricelist b2b '%s' is not supported"
+msgstr ""
+
+#. module: sale_order_pricelist_tax
+#: model:product.product,uom_name:sale_order_pricelist_tax.ak_product
+#: model:product.template,uom_name:sale_order_pricelist_tax.ak_product_product_template
+msgid "Units"
+msgstr ""
+
+#. module: sale_order_pricelist_tax
+#: model:product.product,name:sale_order_pricelist_tax.ak_product
+#: model:product.template,name:sale_order_pricelist_tax.ak_product_product_template
+msgid "ak product"
+msgstr ""

--- a/sale_order_pricelist_tax/models/__init__.py
+++ b/sale_order_pricelist_tax/models/__init__.py
@@ -1,5 +1,7 @@
 from . import account_fiscal_position
 from . import product_product
 from . import product_pricelist
+from . import price_include_mixin
 from . import sale_order
 from . import account_tax
+from . import account_move

--- a/sale_order_pricelist_tax/models/account_move.py
+++ b/sale_order_pricelist_tax/models/account_move.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2022 Akretion (<http://www.akretion.com>).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _name = "account.move"
+    _description = "Account Move"
+    _inherit = ["account.move", "price.include.tax.mixin"]
+
+    @api.depends(
+        "invoice_line_ids.tax_ids.price_include",
+    )
+    def _compute_price_tax_state(self):
+        return super()._compute_price_tax_state()
+
+    def action_post(self):
+        for move in self:
+            if (
+                move.move_type
+                in ["out_invoice", "in_invoice", "out_refund", "in_refund"]
+                and move.price_tax_state == "exception"
+            ):
+                raise UserError(
+                    _(
+                        "Invoice lines must have the same kind of taxes "
+                        "(price include or exclude)."
+                    )
+                )
+        return super().action_post()

--- a/sale_order_pricelist_tax/models/price_include_mixin.py
+++ b/sale_order_pricelist_tax/models/price_include_mixin.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2022 Akretion (<http://www.akretion.com>).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class PriceIncludeTax(models.AbstractModel):
+    _name = "price.include.tax.mixin"
+    _description = "Price Include Tax Check Mixin"
+
+    price_tax_state = fields.Selection(
+        selection=[
+            ("include", "Include"),
+            ("exclude", "Exclude"),
+            ("exception", "Exception"),
+        ],
+        string="Price tax state",
+        compute="_compute_price_tax_state",
+    )
+
+    def _get_all_taxes(self):
+        if self._name == "sale.order":
+            return self.order_line.tax_id
+        if self._name == "account.move":
+            return self.invoice_line_ids.tax_ids
+
+    def _compute_price_tax_state(self):
+        for rec in self:
+            taxes = rec._get_all_taxes()
+            taxe_price_inc = set(taxes.mapped("price_include"))
+            if len(taxe_price_inc) > 1:
+                rec.price_tax_state = "exception"
+            elif len(taxe_price_inc) == 1 and taxe_price_inc.pop():
+                rec.price_tax_state = "include"
+            else:
+                rec.price_tax_state = "exclude"

--- a/sale_order_pricelist_tax/report/invoice_template.xml
+++ b/sale_order_pricelist_tax/report/invoice_template.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template id="report_invoice_document" inherit_id="account.report_invoice_document">
+        <xpath expr="//span[@t-field='line.price_subtotal']" position="replace">
+                <span
+                t-if="o.price_tax_state != 'include'"
+                class="text-nowrap"
+                t-field="line.price_subtotal"
+            />
+                <span
+                t-if="o.price_tax_state == 'include'"
+                class="text-nowrap"
+                t-field="line.price_total"
+            />
+        </xpath>
+    </template>
+</odoo>

--- a/sale_order_pricelist_tax/report/sale_template.xml
+++ b/sale_order_pricelist_tax/report/sale_template.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template
+        id="report_saleorder_document"
+        inherit_id="sale.report_saleorder_document"
+    >
+        <xpath expr="//td[@name='td_subtotal']" position="replace">
+            <td name="td_subtotal" class="text-right o_price_total">
+                <span
+                    t-if="doc.price_tax_state != 'include'"
+                    t-field="line.price_subtotal"
+                    groups=""
+                />
+                <span
+                    t-if="doc.price_tax_state == 'include'"
+                    t-field="line.price_total"
+                    groups=""
+                />
+            </td>
+        </xpath>
+    </template>
+</odoo>

--- a/sale_order_pricelist_tax/tests/__init__.py
+++ b/sale_order_pricelist_tax/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_tax
+from . import test_price_tax_state

--- a/sale_order_pricelist_tax/tests/test_price_tax_state.py
+++ b/sale_order_pricelist_tax/tests/test_price_tax_state.py
@@ -1,0 +1,144 @@
+# © 2018  Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import SavepointCase
+
+from .test_tax import TaxCase
+
+
+class TaxPriceTaxState(TaxCase, SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.sale = cls.env.ref("sale.sale_order_1")
+
+        account_user_type = cls.env.ref("account.data_account_type_receivable")
+
+        cls.account_rec = cls.env["account.account"].create(
+            {
+                "code": "TEST-REC",
+                "name": "Rec - Test",
+                "user_type_id": account_user_type.id,
+                "reconcile": True,
+            }
+        )
+
+        cls.account_sale = cls.env["account.account"].create(
+            {
+                "code": "TEST-SALE",
+                "name": "Sale - Test",
+                "user_type_id": cls.env.ref(
+                    "account.data_account_type_direct_costs"
+                ).id,
+            }
+        )
+
+        cls.sale_journal = cls.env["account.journal"].create(
+            {
+                "name": "Sale Journal - Test",
+                "code": "SALE",
+                "type": "sale",
+                "default_account_id": cls.account_sale.id,
+                "payment_debit_account_id": cls.account_sale.id,
+                "payment_credit_account_id": cls.account_sale.id,
+            }
+        )
+
+    def create_invoice(self, tax1, tax2):
+        invoice = self.env["account.move"].create(
+            [
+                {
+                    "move_type": "out_invoice",
+                    "journal_id": self.sale_journal.id,
+                    "invoice_line_ids": [
+                        (
+                            0,
+                            None,
+                            {
+                                "product_id": self.product.id,
+                                "quantity": 1,
+                                "price_unit": 50,
+                                "account_id": self.env["account.account"]
+                                .search(
+                                    [
+                                        (
+                                            "user_type_id",
+                                            "=",
+                                            self.env.ref(
+                                                "account.data_account_type_revenue"
+                                            ).id,
+                                        )
+                                    ],
+                                    limit=1,
+                                )
+                                .id,
+                                "tax_ids": [
+                                    (
+                                        6,
+                                        0,
+                                        tax1.ids,
+                                    )
+                                ],
+                            },
+                        ),
+                        (
+                            0,
+                            None,
+                            {
+                                "product_id": self.product.id,
+                                "quantity": 1,
+                                "price_unit": 50,
+                                "account_id": self.env["account.account"]
+                                .search(
+                                    [
+                                        (
+                                            "user_type_id",
+                                            "=",
+                                            self.env.ref(
+                                                "account.data_account_type_revenue"
+                                            ).id,
+                                        )
+                                    ],
+                                    limit=1,
+                                )
+                                .id,
+                                "tax_ids": [
+                                    (
+                                        6,
+                                        0,
+                                        tax2.ids,
+                                    )
+                                ],
+                            },
+                        ),
+                    ],
+                }
+            ]
+        )
+        return invoice
+
+    def test_sale_price_tax_include(self):
+        self.sale.order_line.tax_id = self.tax_inc
+        self.assertEqual(self.sale.price_tax_state, "include")
+
+    def test_sale_price_tax_exclude(self):
+        self.sale.order_line.tax_id = self.tax_exc
+        self.assertEqual(self.sale.price_tax_state, "exclude")
+
+    def test_sale_price_tax_exception(self):
+        self.sale.order_line[0].tax_id = self.tax_inc
+        self.sale.order_line[1].tax_id = self.tax_exc
+        self.assertEqual(self.sale.price_tax_state, "exception")
+
+    def test_invoice_price_tax_include(self):
+        invoice = self.create_invoice(self.tax_inc, self.tax_inc)
+        self.assertEqual(invoice.price_tax_state, "include")
+
+    def test_invoice_price_tax_exclude(self):
+        invoice = self.create_invoice(self.tax_exc, self.tax_exc)
+        self.assertEqual(invoice.price_tax_state, "exclude")
+
+    def test_invoice_price_tax_exception(self):
+        invoice = self.create_invoice(self.tax_inc, self.tax_exc)
+        self.assertEqual(invoice.price_tax_state, "exception")

--- a/sale_order_pricelist_tax/views/account_move_view.xml
+++ b/sale_order_pricelist_tax/views/account_move_view.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="account_move_view_form" model="ir.ui.view">
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <header position="after">
+                <div
+                    class="alert alert-danger alert-dismissable"
+                    role="alert"
+                    style="margin-bottom:0px;"
+                    attrs="{'invisible':[('price_tax_state','!=', 'exception')]}"
+                >Invoice lines must have the same type of tax:
+                     <br /> - Either price include tax
+                    <br /> - Either price exclude tax
+                </div>
+            </header>
+            <xpath expr="//field[@name='invoice_date']" position="after">
+                <field name="price_tax_state" invisible="1" />
+            </xpath>
+           <xpath expr="//tree/field[@name='price_subtotal']" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'column_invisible': [('parent.price_tax_state', '=', 'include')]}</attribute>
+                <attribute name="groups" />
+            </xpath>
+            <xpath expr="//tree/field[@name='price_total']" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'column_invisible': [('parent.price_tax_state', '!=', 'include')]}</attribute>
+                <attribute name="groups" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_order_pricelist_tax/views/sale_order_view.xml
+++ b/sale_order_pricelist_tax/views/sale_order_view.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <sheet position="before">
+                <div
+                    class="alert alert-danger alert-dismissable"
+                    role="alert"
+                    style="margin-bottom:0px;"
+                    attrs="{'invisible':[('price_tax_state','!=', 'exception')]}"
+                >Sale Order lines must have the same type of tax:
+                     <br /> - Either price include tax
+                    <br /> - Either price exclude tax
+                </div>
+            </sheet>
+            <xpath expr="//field[@name='date_order']" position="after">
+                <field name="price_tax_state" invisible="1" />
+            </xpath>
+            <xpath expr="//tree/field[@name='price_subtotal']" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'column_invisible': [('parent.price_tax_state', '=', 'include')]}</attribute>
+                <attribute name="groups" />
+            </xpath>
+            <xpath expr="//tree/field[@name='price_total']" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'column_invisible': [('parent.price_tax_state', '!=', 'include')]}</attribute>
+                <attribute name="groups" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Hi @bguillot , @sebastienbeau,

Add a check on sale order and invoice to force homogeneous tax (price include or exclude):
- div error if both kind of tax are present.
- user error on confirmation / validation of sale order/invoice

Also improving view and template:
- On lines, show total amount if taxes are price include, else, show subtotal amount.